### PR TITLE
adding programmatic support for specmatic install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check [Documentation](https://specmatic.in/documentation.html) for more informat
 
 ## Test helper library
 
-`import { startStubServer, startTestServer, loadDynamicStub, installSpecmatics } from 'specmatic';`
+`import { startStubServer, startTestServer, loadDynamicStub, installContracts } from 'specmatic';`
 
 Specmatic JS library exposes methods which can be used in your JS project to setup the tests, as well as do advanced things like load stubs dynamically.
 
@@ -43,6 +43,6 @@ method to start test server.
 
 method to load stub dynamically from inside an automated test.
 
-`installSpecmatics()`
+`installContracts()`
 
-method to install specmatics in local machine.
+method to install specs in local machine.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check [Documentation](https://specmatic.in/documentation.html) for more informat
 
 ## Test helper library
 
-`import { startStubServer, startTestServer, loadDynamicStub } from 'specmatic';`
+`import { startStubServer, startTestServer, loadDynamicStub, installSpecmatics } from 'specmatic';`
 
 Specmatic JS library exposes methods which can be used in your JS project to setup the tests, as well as do advanced things like load stubs dynamically.
 
@@ -43,3 +43,6 @@ method to start test server.
 
 method to load stub dynamically from inside an automated test.
 
+`installSpecmatics()`
+
+method to install specmatics in local machine.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { loadDynamicStub, startStubServer, startTestServer } from './lib';
+export { loadDynamicStub, startStubServer, startTestServer, installSpecmatics } from './lib';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { loadDynamicStub, startStubServer, startTestServer, installSpecmatics } from './lib';
+export { loadDynamicStub, startStubServer, startTestServer, installContracts } from './lib';

--- a/src/lib/__tests__/index.ts
+++ b/src/lib/__tests__/index.ts
@@ -1,7 +1,7 @@
 import execSh from 'exec-sh';
 import fetch from 'node-fetch';
 import path from 'path';
-import { startStubServer, startTestServer, loadDynamicStub } from '../';
+import { startStubServer, startTestServer, loadDynamicStub, installSpecmatics } from '../';
 import { specmaticJarPathLocal } from '../../config';
 import mockStub from '../../../mockStub.json';
 
@@ -32,6 +32,14 @@ describe('Testing helper methods', () => {
     expect(execSh).toHaveBeenCalledTimes(1);
     expect(execSh.mock.calls[0][0])
       .toBe(`java -jar ${path.resolve(specmaticJarPathLocal)} test ${path.resolve(contractsPath)} --host=${host} --port=${port}`);
+  });
+
+  test('installSpecmatics', () => {
+    installSpecmatics();
+
+    expect(execSh).toHaveBeenCalledTimes(1);
+    expect(execSh.mock.calls[0][0])
+      .toBe(`java -jar ${path.resolve(specmaticJarPathLocal)} install`);
   });
 
   test('loadDynamicStub', () => {

--- a/src/lib/__tests__/index.ts
+++ b/src/lib/__tests__/index.ts
@@ -1,7 +1,7 @@
 import execSh from 'exec-sh';
 import fetch from 'node-fetch';
 import path from 'path';
-import { startStubServer, startTestServer, loadDynamicStub, installSpecmatics } from '../';
+import { startStubServer, startTestServer, loadDynamicStub, installContracts } from '../';
 import { specmaticJarPathLocal } from '../../config';
 import mockStub from '../../../mockStub.json';
 
@@ -34,8 +34,8 @@ describe('Testing helper methods', () => {
       .toBe(`java -jar ${path.resolve(specmaticJarPathLocal)} test ${path.resolve(contractsPath)} --host=${host} --port=${port}`);
   });
 
-  test('installSpecmatics', () => {
-    installSpecmatics();
+  test('installContracts', () => {
+    installContracts();
 
     expect(execSh).toHaveBeenCalledTimes(1);
     expect(execSh.mock.calls[0][0])

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,7 +29,7 @@ export const startTestServer = (specmaticDir: string, host: string, port: string
 export const installContracts = () => {
   const specmaticJarPath = path.resolve(specmaticJarPathLocal);
 
-  console.log('installing specmatics in local')
+  console.log('installing contracts in local')
   execSh(
     `java -jar ${specmaticJarPath} install`
   );

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -26,6 +26,15 @@ export const startTestServer = (specmaticDir: string, host: string, port: string
   );
 }
 
+export const installSpecmatics = () => {
+  const specmaticJarPath = path.resolve(specmaticJarPathLocal);
+
+  console.log('installing specmatics in local')
+  execSh(
+    `java -jar ${specmaticJarPath} install`
+  );
+}
+
 export const loadDynamicStub = (stubPath: string) => {
   const stubResponse = require(path.resolve(stubPath))
   fetch('http://localhost:8000/_specmatic/expectations',

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -26,7 +26,7 @@ export const startTestServer = (specmaticDir: string, host: string, port: string
   );
 }
 
-export const installSpecmatics = () => {
+export const installContracts = () => {
   const specmaticJarPath = path.resolve(specmaticJarPathLocal);
 
   console.log('installing specmatics in local')


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding programmatic support for specmatic install command. Feature request: [#1](https://github.com/znsio/specmatic-node/issues/1)

<!-- Why are these changes necessary? -->

**Why**: Need programmatic support to install specmatics in the local environment which will checkout all the specmatics from the repositories given in the specmatic.json. CLI support for specmatic install works but the programmatic version would be needed to be able to write cross-platform script.

<!-- How were these changes implemented? -->

**How**: A simple function has been added that exposes specmatic install command.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->