### PR TITLE
Starting stub server now notifies when start is sucessfull via promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ import {
 
 Specmatic JS library exposes methods which can be used in your JS project to setup the tests, as well as do advanced things like load stubs dynamically. These can be used to programmatically run specmatic commands from any javascript testing framework, during setup or test phases.
 
-`startStubServer(host?: string, port?: string, stubDir?: string)` <br />
+`startStubServer(host?: string, port?: string, stubDir?: string) : Promise<ChildProcess>` <br />
 method to start the stub server.
 
-`runContractTests(specmaticDir: string, host: string, port: string)` <br />
+`runContractTests(specmaticDir: string, host: string, port: string) : Promise<boolean>` <br />
 Alias: `startTestServer` <br />
 method to start test server.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,97 +6,101 @@ import fs from 'fs';
 import { ChildProcess } from 'child_process';
 
 const specmaticJarPath = path.resolve(specmaticJarPathLocal);
-export type Environment = Record<string, string>
+export type Environment = Record<string, string>;
 
 export const setSpecmaticEnvironment = (environmentName: string, environment: Environment) => {
-  let file = null
-  try {
-    file = require(path.resolve(specmatic))
-    for (let environmentVariable in environment) file.environments[environmentName].variables[environmentVariable] = environment[environmentVariable]
-    fs.writeFileSync(path.resolve(specmatic), JSON.stringify(file, null, 2))
-  } catch (e) {
-    if (e.toString().includes("Cannot find module")) console.log(e.toString(), "\nThe file 'specmatic.json' is not present in the root directory of the project.")
-  }
-}
+    let file = null;
+    try {
+        file = require(path.resolve(specmatic));
+        for (let environmentVariable in environment)
+            file.environments[environmentName].variables[environmentVariable] = environment[environmentVariable];
+        fs.writeFileSync(path.resolve(specmatic), JSON.stringify(file, null, 2));
+    } catch (e) {
+        if (e.toString().includes('Cannot find module'))
+            console.log(e.toString(), "\nThe file 'specmatic.json' is not present in the root directory of the project.");
+    }
+};
 
 export const startStubServer = (host?: string, port?: string, stubDir?: string) => {
-  const stubs = path.resolve(stubDir + '');
+    const stubs = path.resolve(stubDir + '');
 
-  var cmd = `java -jar ${specmaticJarPath} stub`;
-  if (stubDir) cmd += ` --data=${stubs}`
-  if (host) cmd += ` --host=${host}`
-  if (port) cmd += ` --port=${port}`
-  console.log(cmd)
+    var cmd = `java -jar ${specmaticJarPath} stub`;
+    if (stubDir) cmd += ` --data=${stubs}`;
+    if (host) cmd += ` --host=${host}`;
+    if (port) cmd += ` --port=${port}`;
+    console.log(cmd);
 
-  console.log('Starting specmatic stub server')
-  const javaProcess = execSh(
-    cmd
-    , {}, (err: any) => {
-      if (err) {
-        console.error('Specmatic stub server exited with error', err);
-      }
+    console.log('Starting specmatic stub server');
+    return new Promise((resolve, _reject) => {
+        const javaProcess = execSh(cmd, { stdio: 'pipe', stderr: 'pipe' }, (err: any) => {
+            if (err) {
+                console.error('Specmatic stub server exited with error', err);
+            }
+        });
+        javaProcess.stdout.on('data', function (data: String) {
+            console.log('STDOUT: ' + data);
+            if (data.indexOf('Stub server is running') > -1) {
+              resolve(javaProcess);
+            }
+        });
+        javaProcess.stderr.on('data', function (data: String) {
+            console.log('STDERR: ' + data);
+        });
     });
-    return javaProcess;
-}
+};
 
 export const stopStubServer = (javaProcess: ChildProcess) => {
-  console.log(`Stopping specmatic server`);
-  javaProcess.removeAllListeners('close');
-  javaProcess.kill();
-}
+    console.log(`Stopping specmatic server`);
+    javaProcess.stdout?.removeAllListeners();
+    javaProcess.stderr?.removeAllListeners();
+    javaProcess.removeAllListeners('close');
+    javaProcess.kill();
+};
 
-export const startTestServer = (specmaticDir: string, host: string, port: string) : Promise<boolean> => {
-  const specmatics = path.resolve(specmaticDir);
+export const startTestServer = (specmaticDir: string, host: string, port: string): Promise<boolean> => {
+    const specmatics = path.resolve(specmaticDir);
 
-  console.log('Running specmatic tests');
+    console.log('Running specmatic tests');
 
-  return new Promise((resolve, _reject) => {
-    execSh(
-      `java -jar ${specmaticJarPath} test ${specmatics} --host=${host} --port=${port}`
-      , {}, (err: any) => {
-        if (err) {
-          console.error('Specmatic test run failed with error', err);
-        }
-        resolve(err == null);
-      });
-  });
-}
+    return new Promise((resolve, _reject) => {
+        execSh(`java -jar ${specmaticJarPath} test ${specmatics} --host=${host} --port=${port}`, {}, (err: any) => {
+            if (err) {
+                console.error('Specmatic test run failed with error', err);
+            }
+            resolve(err == null);
+        });
+    });
+};
 
 export const runContractTests = startTestServer;
 
 export const installContracts = () => {
-  console.log('Installing contracts')
-  execSh(
-    `java -jar ${specmaticJarPath} install`
-    , {}, (err: any) => {
-      if (err) {
-        console.error('Installing contracts failed with error', err);
-      }
+    console.log('Installing contracts');
+    execSh(`java -jar ${specmaticJarPath} install`, {}, (err: any) => {
+        if (err) {
+            console.error('Installing contracts failed with error', err);
+        }
     });
-}
+};
 
 export const installSpecs = installContracts;
 
 export const loadDynamicStub = (stubPath: string, stubServerBaseUrl?: string) => {
-  const stubResponse = require(path.resolve(stubPath));
+    const stubResponse = require(path.resolve(stubPath));
 
-  console.log("Setting expectations");
-  fetch(`${stubServerBaseUrl ? stubServerBaseUrl : `http://localhost:9000/`}_specmatic/expectations`,
-    {
-      method: 'POST',
-      body: JSON.stringify(stubResponse)
-    })
-    .then(json => console.log(json));
+    console.log('Setting expectations');
+    fetch(`${stubServerBaseUrl ? stubServerBaseUrl : `http://localhost:9000/`}_specmatic/expectations`, {
+        method: 'POST',
+        body: JSON.stringify(stubResponse),
+    }).then(json => console.log(json));
 };
 
 export const setExpectations = loadDynamicStub;
 
 export const printSpecmaticJarVersion = () => {
-  execSh(
-    `java -jar ${specmaticJarPath} --version`
-    , {}, (err: any) => {
-      if (err) {
-        console.error('Could not print specmatic version', err);
-      }
+    execSh(`java -jar ${specmaticJarPath} --version`, {}, (err: any) => {
+        if (err) {
+            console.error('Could not print specmatic version', err);
+        }
     });
-}
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,7 +21,7 @@ export const setSpecmaticEnvironment = (environmentName: string, environment: En
     }
 };
 
-export const startStubServer = (host?: string, port?: string, stubDir?: string) => {
+export const startStubServer = (host?: string, port?: string, stubDir?: string) : Promise<ChildProcess> => {
     const stubs = path.resolve(stubDir + '');
 
     var cmd = `java -jar ${specmaticJarPath} stub`;


### PR DESCRIPTION
…t need an arbitrary wait before accessing the server endpoint

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Starting stub server now notifies via promise when start is complete so that server is ready for operations

<!-- Why are these changes necessary? -->

**Why**: So that we don't have to have an arbitrary wait before accessing the stub server

<!-- How were these changes implemented? -->

**How**: 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the README.md
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->