### PR TITLE
fix: Typo in import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Specmatic JS library exposes some of the commands as methods that can be run pro
 ```javascript
 import {
     startHttpStub,
-    setHttpStubExpecations,
+    setHttpStubExpectations,
     stopHttpStub,
     test,
     showTestResults,


### PR DESCRIPTION
**What**:

The JavaScript import example in Readme contains a typo. Importing function `setHttpStubExpecations` causes error. 
> '"specmatic"' has no exported member named 'setHttpStubExpecations'. Did you mean 'setHttpStubExpectations'?

**Why**:

 Its the first thing that everybody copies form the readme. It should work.

**How**:

Replace with the correct name `setHttpStubExpectations`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->