### PR TITLE
Add setExpectationJson 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Specmatic JS library exposes some of the commands as methods that can be run pro
 ```javascript
 import {
     startHttpStub,
+    setExpectationJson,
     setHttpStubExpectations,
     stopHttpStub,
     test,
@@ -70,8 +71,11 @@ import {
 Start the stub server. Argument `args` values are passed directly to specmatic jar executable.<br />
 *Note: This replaces `startStub` method which is deprecated*
 
+`setExpectationJson(stubResponse: any, stubServerBaseUrl?: string): Promise<boolean>` <br />
+Set stub expectation from a static JSON object. Stub should be running before invoking this method.<br />
+
 `setHttpStubExpectations(stubPath: string, stubServerBaseUrl?: string): Promise<boolean>` <br />
-Set stub expectiona. Stub should be running before invoking this method.<br />
+Set stub expectation from a file. Stub should be running before invoking this method.<br />
 *Note: This replaces `setExpectations` method which is deprecated*
 
 `stopHttpStub(stub: Stub)` <br />

--- a/src/core/__tests__/set.expectation.ts
+++ b/src/core/__tests__/set.expectation.ts
@@ -12,6 +12,30 @@ beforeEach(() => {
     mockReset(axios);
 });
 
+test('setExpectations with static object', async () => {
+    axios.post.mockResolvedValue({ status: 200 });
+
+    const data = {
+        "mock-http-request": {
+            "method": "GET",
+            "path": "/v1/resource/1"
+        },
+        "mock-http-response": {
+            "status": 200,
+            "body": {
+                "id": 1,
+                "name": "resource name"
+            }
+        }
+    }
+
+    await expect(specmatic.setExpectationJson(data)).toResolve();
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(axios.post.mock.calls[0][0]).toBe('http://localhost:9000/_specmatic/expectations');
+    expect(axios.post.mock.calls[0][1]).toMatchObject(mockStub);
+});
+
 test('setExpectations with default baseUrl', async () => {
     axios.post.mockResolvedValue({ status: 200 });
     await expect(specmatic.setExpectations(path.resolve(STUB_PATH))).toResolve();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -152,6 +152,10 @@ const showTestResults = (testFn: (name: string, cb: () => void) => void) => {
 
 const setExpectations = (stubPath: string, stubServerBaseUrl?: string): Promise<void> => {
     const stubResponse = require(path.resolve(stubPath))
+    return setExpectationJson(stubResponse, stubServerBaseUrl)
+}
+
+const setExpectationJson = (stubResponse: any, stubServerBaseUrl?: string): Promise<void> => {
     stubServerBaseUrl = stubServerBaseUrl || 'http://localhost:9000'
 
     logger.info(`Set Expectations: Stub url is ${stubServerBaseUrl}`)
@@ -257,5 +261,5 @@ function extractEndPoints(expressApp: any) {
     return springActuatorPayload
 }
 
-export { startStub, stopStub, test, testWithApiCoverage, setExpectations, printJarVersion, showTestResults }
+export { startStub, stopStub, test, testWithApiCoverage, setExpectations, setExpectationJson, printJarVersion, showTestResults }
 export { startApiCoverageServer }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
     testWithApiCoverage,
     setExpectations,
     setExpectations as setHttpStubExpectations,
+    setExpectationJson,
     printJarVersion,
     showTestResults,
 } from './core'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow users of this lib to directly pass a static JSON object that is contains the mapping for the expectation with `http-request` and `http-response` blocks. Send it to the [Specmatic expectations API](https://specmatic.in/documentation/service_virtualization_tutorial.html#expectations-http-endpoint) which is used for setting dynamic expectations.

<!-- Why are these changes necessary? -->

**Why**:

Sometimes we would like to setup the mock and define request/response from code the test code, without writing it to a json file in the consumer's Git repo.

<!-- How were these changes implemented? -->

**How**:

Create another function call it `setExpectationJson`. Reuse it in the the [setExpectations](https://github.com/znsio/specmatic-node/blob/1304c1c94eb3867284646f4cdab037927e2df8ae/src/core/index.ts#L153) function is internally just reading the JSON contents of the file and sending it via the new `setExpectationJson` function.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Resolves https://github.com/znsio/specmatic-node/issues/138