### PR TITLE
Updated NPM Script To Add Specmatic.jar Before Packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+/node_modules
+/coverage
+.vscode/settings.json
+.DS_Store
+dist/test-report

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "specmatic",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir dist --ignore 'src/**/__tests__/**/*.ts' --extensions \".ts,.tsx\" --source-maps inline",
     "test": "rimraf coverage && jest --coverage",
-    "postinstall": "node src/downloadSpecmaticJar.js"
+    "prepack": "node src/downloadSpecmaticJar.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What:**

This PR modifies the download sequence of specmatic.jar in the Specmatic NPM package. Instead of downloading specmatic.jar after the package installation (using a postinstall script), the jar file is now downloaded before the package is packed (using a prepack script).

**Why:**

The modification ensures that specmatic.jar is bundled within the package at the time of packing. This approach helps to avoid potential issues where the jar file might not be correctly included when the package is installed.

**How:**

The implementation involved switching from a postinstall script to a prepack script in the package.json file. This script handles the downloading of specmatic.jar and ensures it is added to the correct directory before the package is packed.