### PR TITLE
Filter regex from path to resolve missing in spec issue

### DIFF
--- a/src/core/__tests__/end.points.api.ts
+++ b/src/core/__tests__/end.points.api.ts
@@ -70,6 +70,13 @@ test('coverts express route multiple variable syntax to spring request mapping s
     expect(res.body).toStrictEqual(response)
 })
 
+test('converts express route with regex path parameter to spring request mapping syntax', async () => {
+    app.get('/api/orders/:orderId([0-9])/items/:itemId([0-9a-f]{24})', () => { });
+    const res = await request(server).get('/').accept('application/json').expect(200)
+    const response = generateResponseObject({ '/api/orders/{orderId}/items/{itemId}': ['GET'] })
+    expect(res.body).toStrictEqual(response)
+})
+
 test('removes escaped dot and backslash in url', async () => {
     app.get('/v1\\.0/:store/:id', () => {})
     const res = await request(server).get('/').accept('application/json').expect(200)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -254,12 +254,20 @@ function extractEndPoints(expressApp: any) {
                 details: {
                     requestMappingConditions: {
                         methods: endPoints[path].sort(),
-                        patterns: [path.replace(/:([^/]+)/g, '{$1}').replace(/\\/g, '')],
+                        patterns: [convertEndpointToSpringSyntax(path)].map(removeRegexFromPath)
                     },
                 },
             } as never)
         })
     return springActuatorPayload
+}
+
+const convertEndpointToSpringSyntax = (path: string) => {
+    return path.replace(/:([^/]+)/g, '{$1}').replace(/\\/g, '')
+}
+
+const removeRegexFromPath = (path: string) => {
+    return path.replace(/\([^()]*\)/g, '')
 }
 
 export { startStub, stopStub, test, testWithApiCoverage, setExpectations, setExpectationJson, printJarVersion, showTestResults }


### PR DESCRIPTION
**What**:
Updated the logic around how the endpoints are extracted from custom node actuator to **get rid of any regexes in the path**.

**Why**:
If we have an endpoint with regex in path, e.g. - **/public-extension/:extension_id([0-9a-f]{24})**
Then in the api coverage summary, we used to get the output as follows:

```
/public-extension/{extension_id([0-9a-f]{24})}  => missing in spec
/public-extension/{extension_id} => covered
```
To get rid of the endpoint with the regex from API coverage report, we had to make this change.
P.S. Removing that endpoint from API coverage report won't affect anything since the endpoint is anyways getting tested
as part of the path **/public-extension/{extension_id}**

**How**:
We are removing the regex part from the endpoint string while extracting endpoints from node actuator.


**Checklist**:
- [x] Tests
- [x] Ready to be merged

