### PR TITLE
Retrieve Specmatic Text Error Messages for setExpectationJson

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -169,7 +169,17 @@ const setExpectationJson = (stubResponse: any, stubServerBaseUrl?: string): Prom
                 resolve()
             })
             .catch(err => {
-                const setExpectationsErrorMessage = `Set Expectations: Failed with error ${err}`
+                var setExpectationsErrorMessage = `Set Expectations: Failed with error ${err}`
+                // Check if the response data is in text format
+                if (err.response?.headers['content-type'] === 'text/plain') {
+                    try {
+                        // Use a check to handle text content
+                        const errorText = typeof err.response.data === 'string' ? err.response.data : "Error text not available";
+                        setExpectationsErrorMessage += ` - ${errorText}`;
+                    } catch (e) {
+                        logger.error("Failed to retrieve text error message.");
+                    }
+                }
                 logger.error(setExpectationsErrorMessage)
                 reject(setExpectationsErrorMessage)
             })


### PR DESCRIPTION

**What**: Retrieve Specmatic Text Error Messages for setExpectationJson

**Why**: Since Specmatic returns error messages in text format, retrieving detailed error information from `_specmatic/expectations` in the `setExpectationJson` method has been challenging. Previously, only the error code was captured, making it difficult to identify which fields were incorrect or missing according to the OpenAPI specifications. This update addresses the issue by capturing and logging the full text error message, enabling more precise troubleshooting.

**How**: Added error handling to return error message also along with error code.

**Checklist**:

- [ ] Documentation added to the README.md
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
 
**Screenshot**:
<img width="1277" alt="Screenshot 2024-11-13 at 5 33 46 PM" src="https://github.com/user-attachments/assets/891d1498-9734-4830-9de6-61e932fd045b">


It will be very helpful if we get error message also in console when running consumer driven contract tests.
